### PR TITLE
POC: prov/efa: Add option to avoid Memory Registrations when possible

### DIFF
--- a/prov/efa/src/efa_env.c
+++ b/prov/efa/src/efa_env.c
@@ -195,6 +195,8 @@ void efa_env_define()
 			"Set the number of EFA completion entries to read for one loop for one iteration of the progress engine. (Default: 50)");
 	fi_param_define(&efa_prov, "shm_cq_read_size", FI_PARAM_SIZE_T,
 			"Set the number of SHM completion entries to read for one loop for one iteration of the progress engine. (Default: 50)");
+	fi_param_define(&efa_prov, "avoid_mr", FI_PARAM_BOOL,
+			"Whenever possible, do not register memory to EFA device.  Instead prefer bounce-buffers.  Default: no");
 	fi_param_define(&efa_prov, "inter_max_medium_message_size", FI_PARAM_INT,
 			"The maximum message size for inter EFA medium message protocol (Default 65536).");
 	fi_param_define(&efa_prov, "inter_min_read_message_size", FI_PARAM_INT,

--- a/prov/efa/src/efa_hmem.c
+++ b/prov/efa/src/efa_hmem.c
@@ -35,6 +35,7 @@ static int efa_domain_hmem_info_init_protocol_thresholds(struct efa_domain *efa_
 	/* Fall back to FI_HMEM_SYSTEM initialization logic when p2p is unavailable */
 	if (!info->p2p_supported_by_device)
 		iface = FI_HMEM_SYSTEM;
+	info->avoid_mr = 0;
 
 	switch (iface) {
 	case FI_HMEM_SYSTEM:
@@ -48,6 +49,7 @@ static int efa_domain_hmem_info_init_protocol_thresholds(struct efa_domain *efa_
 		fi_param_get_size_t(&efa_prov, "inter_max_medium_message_size", &info->max_medium_msg_size);
 		fi_param_get_size_t(&efa_prov, "inter_min_read_message_size", &info->min_read_msg_size);
 		fi_param_get_size_t(&efa_prov, "inter_min_read_write_size", &info->min_read_write_size);
+		fi_param_get_bool(&efa_prov, "avoid_mr", &info->avoid_mr);
 		break;
 	case FI_HMEM_CUDA:
 		info->runt_size = EFA_DEFAULT_RUNT_SIZE;

--- a/prov/efa/src/efa_hmem.h
+++ b/prov/efa/src/efa_hmem.h
@@ -26,6 +26,7 @@ struct efa_hmem_info {
 	bool p2p_disabled_by_user;	/* Did the user disable p2p via FI_OPT_FI_HMEM_P2P? */
 	bool p2p_required_by_impl;	/* Is p2p required for this interface? */
 	bool p2p_supported_by_device;	/* do we support p2p with this device */
+	int avoid_mr; /* bool: avoid MR when possible for send/recv. Uses bounce-buffers instead. */
 
 	size_t max_intra_eager_size; /* Maximum message size to use eager protocol for intra-node */
 	size_t max_medium_msg_size;

--- a/prov/efa/src/rdm/efa_rdm_ope.c
+++ b/prov/efa/src/rdm/efa_rdm_ope.c
@@ -270,9 +270,15 @@ void efa_rdm_ope_try_fill_desc(struct efa_rdm_ope *ope, int mr_iov_start, uint64
 {
 	int i, err;
 
+	bool avoid_mr = efa_rdm_ep_domain(ope->ep)->hmem_info[FI_HMEM_SYSTEM].avoid_mr;
 	for (i = mr_iov_start; i < ope->iov_count; ++i) {
 		if (ope->desc[i])
 			continue;
+
+		if (avoid_mr) {
+			ope->mr[i] = NULL;
+			continue;
+		}
 
 		err = fi_mr_regv(
 			&efa_rdm_ep_domain(ope->ep)->util_domain.domain_fid,


### PR DESCRIPTION
This PR is not intended for merge, but rather discussion of the Memory Registration performance.

I have noticed that at times temporary buffers pose a challenge to performance.  In particular if the program break continues to map/unmap the temporary buffer, then we pay the MR cost every single time with no amortized benefit.

This PR is for testing what kind of performance we could recover if we deferred registrations in such cases, but it is not a solution to the problem.

